### PR TITLE
ci: adding secrets needed for publication

### DIFF
--- a/.github/maven.settings.xml
+++ b/.github/maven.settings.xml
@@ -42,12 +42,22 @@
             <password>${env.NEXUS_PASSWORD}</password>
         </server>
         <server>
+            <id>jahia-internal</id>
+            <username>${env.NEXUS_USERNAME}</username>
+            <password>${env.NEXUS_PASSWORD}</password>
+        </server>
+        <server>
             <id>jahia-snapshots</id>
             <username>${env.NEXUS_USERNAME}</username>
             <password>${env.NEXUS_PASSWORD}</password>
         </server>
         <server>
-            <id>jahia-internal</id>
+            <id>staging-repository</id>
+            <username>${env.NEXUS_USERNAME}</username>
+            <password>${env.NEXUS_PASSWORD}</password>
+        </server>
+        <server>
+            <id>jahia-releases</id>
             <username>${env.NEXUS_USERNAME}</username>
             <password>${env.NEXUS_PASSWORD}</password>
         </server>


### PR DESCRIPTION
The release failed due to missing credentials.