### PR TITLE
fix: fixed incorrect module signature in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <relativePath />
     </parent>
     <artifactId>site-settings-publication</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>Site Settings - Publication</name>
     <description>DX module that provides a new site settings panel for triggering publication of whole site or a sub-tree of the site</description>
@@ -67,7 +67,7 @@
 
     <properties>
         <jahia-depends>default,siteSettings</jahia-depends>
-        <jahia-module-signature>MCwCFBtRi92akvXBPnx+CM/w+8cEA8YBAhQFhp+PT2BhBfdq+7G7ZMRrfhigBA==</jahia-module-signature>
+        <jahia-module-signature>MCwCFD9oxbdzAol2OkRCDcrxLbDk1wo1AhRDpnLZUedtYdAGSKWeZUnjmIFqFQ==</jahia-module-signature>
         <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"</require-capability>
         <import-package>org.springframework.web.servlet.tags</import-package>
     </properties>


### PR DESCRIPTION
The previous release of the module had an incorrect module signature, preventing its installation.

Corrected release will be 2.2.1