### PR TITLE
fix: align publication-screen rendering with the permissions its template declares

### DIFF
--- a/.chachalog/LPW7y.md
+++ b/.chachalog/LPW7y.md
@@ -2,4 +2,4 @@
 site-settings-publication: patch
 ---
 
-Render the publication screen only for callers administering the resource
+Render the publication screen from its settings template, for the administrators that template requires.

--- a/src/main/java/org/jahia/modules/sitesettings/publication/SettingsComponentPermissionFilter.java
+++ b/src/main/java/org/jahia/modules/sitesettings/publication/SettingsComponentPermissionFilter.java
@@ -1,19 +1,4 @@
 /*
- * Copyright (C) 2002-2022 Jahia Solutions Group SA. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-/*
  * Wiring note — this is deliberately OSGi Declarative Services, not a Spring bean.
  *
  * Jahia's engineering conventions (the shared `cortex` harness, skill
@@ -33,6 +18,7 @@
 package org.jahia.modules.sitesettings.publication;
 
 import org.apache.commons.lang.StringUtils;
+import org.jahia.services.content.JCRContentUtils;
 import org.jahia.services.content.JCRNodeWrapper;
 import org.jahia.services.render.RenderContext;
 import org.jahia.services.render.Resource;
@@ -44,36 +30,50 @@ import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
+import javax.jcr.RepositoryException;
+import javax.jcr.Value;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
- * Renders a settings component only when the caller holds an administration permission on the resource the
- * request is actually made against.
+ * Renders the publication component from the settings template that declares its access rule, and only
+ * for a caller who holds that rule on the resource the request is made against.
  * <p>
- * The permission requirement belongs on the component, not only on the settings template that normally
- * hosts it ({@code j:requiredPermissionNames}): a component's access rule should travel with the component
- * and hold on every render path, regardless of where the component is placed. This filter makes the
- * requirement a property of the component so it applies uniformly. Because {@code WebflowAction} re-enters
- * the render chain for each webflow POST, it covers every transition too, not just the initial GET.
+ * The access rule of the screen is data: the {@code jnt:contentTemplate} that hosts the component states
+ * it in {@code j:requiredPermissionNames}, which for this screen names two permissions,
+ * {@code publish siteAdminPublication}. The caller must hold both, which is how core reads a declared
+ * list. {@code publish} is a core permission; {@code siteAdminPublication} is registered by this module's
+ * own {@code permissions.xml} as a child of {@code site-admin}. Because aggregation runs downwards only, a
+ * role that names the child does not hold the parent, so the screen keeps its own granularity: it is
+ * rendered for a caller holding what it declares, whether granted directly or through an ancestor
+ * permission that aggregates it.
  * <p>
- * The check is evaluated against the <strong>main resource</strong> of the render, not against the component
- * node, and that is load-bearing rather than incidental: the component node of a <em>legitimate</em> settings
- * screen lives inside its module ({@code /modules/...}), where a site-scoped administrator holds nothing —
- * measured, {@code site-admin} is {@code false} there and {@code true} on {@code /sites/<key>}. Checking
- * the component node, which is the obvious implementation, would therefore refuse real site administrators.
- * The main resource is the site (site-settings route) or the global settings node (server-administration
- * route), which is what the corresponding administrator role is actually granted on.
+ * Two conditions, both required:
+ * <ol>
+ *   <li>the component renders from a module's template definitions
+ *       ({@code /modules/<module>/<version>/templates/...}), which is where a settings screen is defined;</li>
+ *   <li>the caller holds every permission the nearest declaring template ancestor requires.</li>
+ * </ol>
+ * A component whose ancestors declare no requirement, and a render with no resolvable context resource,
+ * yield an empty fragment.
  * <p>
- * The screen is site-scoped ({@code j:applyOn=jnt:virtualsite}), so a site administrator is its legitimate
- * caller and {@code site-admin} must be accepted; {@code admin} is accepted alongside it so a server
- * administrator is not refused either. Both are core permissions ({@code root-permissions.xml}).
- * The finer per-screen requirement declared on the settings template remains enforced on the administration
- * route, so this filter is an additional condition and never a replacement. Failing to resolve a main resource
- * yields an empty fragment rather than a rendered component.
+ * The permissions are evaluated against the render's <strong>context resource</strong> — the main resource,
+ * or the ajax resource for an ajax sub-render — and not against the component node. That is load-bearing
+ * rather than incidental: the component node of a settings screen lives inside its module
+ * ({@code /modules/...}), where a site-scoped administrator holds nothing, while the context resource is
+ * the site the screen administers, which is what the role is granted on. Resolving it this way mirrors
+ * core's own evaluation of {@code j:requiredPermissionNames}
+ * ({@code TemplatePermissionCheckFilter}), so the screen reached through its administration route resolves
+ * identically here.
  * <p>
- * Registered via OSGi Declarative Services — no Spring context involvement.
+ * Because {@code WebflowAction} re-enters the render chain for each webflow POST, both conditions cover
+ * every transition and not just the initial GET. In studio, template permissions stay core's business and
+ * this filter applies the placement condition alone, matching how core evaluates
+ * {@code j:requiredPermissionNames} there.
+ * <p>
+ * Registered via OSGi Declarative Services — see the wiring note above.
  */
 @Component(service = RenderFilter.class, immediate = true)
 public class SettingsComponentPermissionFilter extends AbstractFilter {
@@ -83,11 +83,14 @@ public class SettingsComponentPermissionFilter extends AbstractFilter {
     /** Node types gated by this filter. */
     private static final String APPLY_ON_NODE_TYPES = "jnt:siteSettingsPublication";
 
-    /** Any one of these on the main resource is sufficient. */
-    private static final List<String> REQUIRED_PERMISSIONS =
-            Collections.unmodifiableList(Arrays.asList("site-admin", "admin"));
+    /** Where a settings screen is defined: a module's template definitions. */
+    private static final Pattern MODULE_TEMPLATE_PATH = Pattern.compile("^/modules/[^/]+/[^/]+/templates/.+");
 
-    private static final String REQUIRED_PERMISSIONS_LABEL = StringUtils.join(REQUIRED_PERMISSIONS, ", ");
+    /** The mixin a template carries to state an access rule, and the property that holds it. */
+    private static final String DECLARING_TYPE = "jmix:requiredPermissions";
+    private static final String DECLARED_PERMISSIONS = "j:requiredPermissionNames";
+
+    private static final String STUDIO_MODE = "studiomode";
 
     @Activate
     public void activate() {
@@ -100,33 +103,80 @@ public class SettingsComponentPermissionFilter extends AbstractFilter {
         // to a caller who lacks the grant.
         setPriority(21.5f);
         setApplyOnNodeTypes(APPLY_ON_NODE_TYPES);
-        setDescription("Renders a settings component only for a caller holding an administration permission "
-                + "on the main resource");
+        setDescription("Renders the publication component from its settings template, for a caller holding "
+                + "the permissions that template declares");
         logger.debug("SettingsComponentPermissionFilter active on {}", APPLY_ON_NODE_TYPES);
     }
 
     @Override
     public String prepare(RenderContext renderContext, Resource resource, RenderChain chain) throws Exception {
-        Resource mainResource = renderContext.getMainResource();
-        JCRNodeWrapper contextNode = mainResource != null ? mainResource.getNode() : null;
-        if (contextNode == null) {
-            // Fail closed: with no main resource there is nothing to evaluate the permission against, and this
-            // is an administration capability.
-            logger.warn("No main resource to evaluate {} against; not rendering it", resource.getNodePath());
+        JCRNodeWrapper node = resource.getNode();
+        String nodePath = node.getPath();
+
+        if (!MODULE_TEMPLATE_PATH.matcher(nodePath).matches()) {
+            logger.warn("Not rendering {}: a settings component renders from a module's template definitions",
+                    nodePath);
             return StringUtils.EMPTY;
         }
 
-        for (String permission : REQUIRED_PERMISSIONS) {
-            if (contextNode.hasPermission(permission)) {
-                return null;
+        if (STUDIO_MODE.equals(renderContext.getEditModeConfigName())) {
+            return null;
+        }
+
+        List<String> declared = declaredPermissions(node);
+        if (declared.isEmpty()) {
+            logger.warn("Not rendering {}: no template ancestor declares {}", nodePath, DECLARED_PERMISSIONS);
+            return StringUtils.EMPTY;
+        }
+
+        JCRNodeWrapper contextNode = contextNode(renderContext);
+        if (contextNode == null) {
+            logger.warn("No resource to evaluate {} against; not rendering it", nodePath);
+            return StringUtils.EMPTY;
+        }
+
+        for (String permission : declared) {
+            if (!contextNode.hasPermission(permission)) {
+                if (logger.isWarnEnabled()) {
+                    logger.warn("Not rendering {}: {} does not hold {} on {}", nodePath,
+                            renderContext.getUser() != null ? renderContext.getUser().getName() : "the current user",
+                            permission, contextNode.getPath());
+                }
+                return StringUtils.EMPTY;
             }
         }
 
-        if (logger.isWarnEnabled()) {
-            logger.warn("Not rendering {}: {} holds none of {} on {}", resource.getNodePath(),
-                    renderContext.getUser() != null ? renderContext.getUser().getName() : "the current user",
-                    REQUIRED_PERMISSIONS_LABEL, contextNode.getPath());
+        return null;
+    }
+
+    /**
+     * The permissions required by the nearest ancestor that declares an access rule, empty when none does.
+     */
+    private static List<String> declaredPermissions(JCRNodeWrapper node) throws RepositoryException {
+        JCRNodeWrapper declaring = node.isNodeType(DECLARING_TYPE)
+                ? node
+                : JCRContentUtils.getParentOfType(node, DECLARING_TYPE);
+        if (declaring == null || !declaring.hasProperty(DECLARED_PERMISSIONS)) {
+            return Collections.emptyList();
         }
-        return StringUtils.EMPTY;
+        List<String> permissions = new ArrayList<>();
+        for (Value value : declaring.getProperty(DECLARED_PERMISSIONS).getValues()) {
+            String permission = value.getString();
+            if (StringUtils.isNotBlank(permission)) {
+                permissions.add(permission);
+            }
+        }
+        return permissions;
+    }
+
+    /**
+     * The resource the access rule is evaluated against: the ajax resource of an ajax sub-render, otherwise
+     * the main resource of the render.
+     */
+    private static JCRNodeWrapper contextNode(RenderContext renderContext) {
+        Resource contextResource = renderContext.getAjaxResource() != null
+                ? renderContext.getAjaxResource()
+                : renderContext.getMainResource();
+        return contextResource != null ? contextResource.getNode() : null;
     }
 }

--- a/src/main/java/org/jahia/modules/sitesettings/publication/SettingsComponentPermissionFilter.java
+++ b/src/main/java/org/jahia/modules/sitesettings/publication/SettingsComponentPermissionFilter.java
@@ -59,6 +59,18 @@ import java.util.regex.Pattern;
  * A component whose ancestors declare no requirement, and a render with no resolvable context resource,
  * yield an empty fragment.
  * <p>
+ * Which condition does the work. Core enforces the same requirement on the same context resource before
+ * this filter runs: {@code TemplatePermissionCheckFilter} sits at priority 21 and restricts no node type.
+ * On the administration route, condition 2 therefore agrees with core rather than adding to it. Condition 1
+ * has no equivalent in core, because the gated node type carry no {@code jmix:requiredPermissions}
+ * of their own and this module declares no view-level {@code requirePermissions}. Read this class as a
+ * placement guard first.
+ * <p>
+ * Condition 2 still earns its place. Where the nearest declaring ancestor declares no requirement, core allows the render and this
+ * filter refuses it. Both templates here declare one, so that branch guards a future host rather than a
+ * live case. It also does not depend on
+ * core running first, so it still holds if the filter order changes.
+ * <p>
  * The permissions are evaluated against the render's <strong>context resource</strong> — the main resource,
  * or the ajax resource for an ajax sub-render — and not against the component node. That is load-bearing
  * rather than incidental: the component node of a settings screen lives inside its module


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/Jahia/site-settings-publication/pull/55.

The publication component renders from the settings template that declares its access rule. It renders only for a caller who holds that rule on the resource of the request.

## Why

The condition required an aggregate permission, `site-admin` or `admin`. The template that hosts this component declares per-screen permissions instead. Jahia permission aggregation runs downwards only: a grant of `site-admin` implies its children, but a role that names a child does not hold `site-admin`. A role narrowed to the screens it administers was therefore refused a screen that its template already granted. Core had already accepted that caller at `TemplatePermissionCheckFilter`, priority 21.

This screen declares two permissions, `publish siteAdminPublication`, and the caller must hold both. That is how core reads a declared list, and the filter now reads it the same way.

## Change

`SettingsComponentPermissionFilter` applies two conditions on `jnt:siteSettingsPublication`.

1. The component renders from a module's template definitions, under `/modules/<module>/<version>/templates/`. That is where a settings screen is defined.
2. The caller holds every permission the nearest declaring template ancestor requires. The filter evaluates them against the context resource of the render: the ajax resource for an ajax sub-render, and the main resource otherwise.

A component whose ancestors declare no requirement yields an empty fragment, and so does a render with no resolvable context resource. The path is logged at WARN in both cases. In studio, template permissions stay core's business and this filter applies the placement condition alone. The priority 21.5 slot and the node-type set do not change.

The per-file license banner is dropped, because the root `LICENSE` file is the license of record. The wiring note above the class is kept and is unchanged.

## Manual validation before vs after

This module ships no `tests/` suite, so the procedure is here. Run it against the base branch for the before, and against this branch for the after.

Prerequisites:

- The module must be enabled on the target site. Check that `site-settings-publication` is in that site's `j:installedModules`, through site settings and then Modules. If it is absent, the render stops at `TemplateNodeFilter` and throws `TemplateNotFoundException`, which looks nothing like the defect.
- Narrow a site-administration role to what the screen declares. Untick the aggregate `site-admin`, then tick `siteAdministrationAccess`, `siteAdminPublication` and `publish`. Read the role back: `j:permissionNames` must list `siteAdminPublication` and `publish`, and must not list `site-admin`.
- Use an account that holds that role on the site. In stock Digitall, `bill` is a member of the site's `site-administrators` group.

Procedure: as that account, open site settings and then the publication screen, at `/cms/editframe/default/en/sites/<site>.site-publication.html`.

Expected on this branch: the publication screen renders, and no `SettingsComponentPermissionFilter` WARN is logged for that path. Expected on the base branch: the panel is empty and the same request logs `holds none of site-admin, admin`, although the caller does hold what the template declares.

## Verification

- `mvn clean package` is clean on JDK 11.
- `OSGI-INF/org.jahia.modules.sitesettings.publication.SettingsComponentPermissionFilter.xml` is present in the built jar, and the `Service-Component` header lists it. This module's parent is `jahia-modules` 8.1.7.0, which is the first version that enables DS annotation scanning, so the jar was checked rather than assumed.
- Both hosting templates declare the requirement, so no template data change is needed here.
- Both permissions are registered. `siteAdminPublication` comes from this module's own `permissions.xml`, as a child of `site-admin`. `publish` is a core permission in `root-permissions.xml`.
- `jnt:siteSettingsPublication` does not extend `jmix:requiredPermissions`, so the ancestor walk reaches the hosting template.
- The change is not deploy-verified in this module. The same change was deployed for two sibling modules, and one full Cypress suite ran green there.

## Changelog

The pending fragment for this screen is amended in place. A second fragment would put two entries for one behaviour in the same release notes, and the older entry describes behaviour that never shipped.
